### PR TITLE
Ubuntu lasfile changes

### DIFF
--- a/.github/workflows/testing_checks.yaml
+++ b/.github/workflows/testing_checks.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - develop
-      - ubuntu_lasfile_changes
   pull_request:
     branches:
       - master

--- a/.github/workflows/testing_checks.yaml
+++ b/.github/workflows/testing_checks.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - develop
+      - ubuntu_lasfile_changes
   pull_request:
     branches:
       - master

--- a/agpypeline/entrypoint.py
+++ b/agpypeline/entrypoint.py
@@ -374,7 +374,8 @@ def add_parameters(parser: argparse.ArgumentParser, algorithm_instance: Algorith
 
     # Assume the rest of the arguments are the files
     parser.add_argument('file_list', nargs='*', type=argparse.FileType('r'),
-                        help='additional files for transformer')
+                        help='additional files, folders, and other information'
+                             ' for the transformer')
 
 
 def do_work(parser: argparse.ArgumentParser, configuration_info: Configuration,

--- a/packages.txt
+++ b/packages.txt
@@ -1,1 +1,0 @@
-liblas-bin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-liblas
 PyYAML
 numpy
 piexif

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="agpypeline",
-    version="0.0.47",
+    version="0.0.103",
     author="Jacob van der Leeuw",
     author_email="jvanderleeuw@email.arizona.edu",
     description="Installable package for entrypoint and drone-specific environment code within a transformer",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="agpypeline",
-    version="0.0.104",
+    version="0.0.106",
     author="Jacob van der Leeuw",
     author_email="jvanderleeuw@email.arizona.edu",
     description="Installable package for entrypoint and drone-specific environment code within a transformer",
@@ -24,7 +24,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.7',
-    install_requires=['setuptools', 'numpy', 'influxdb', 'laspy', 'requests>=2.21.0', 'python-dateutil', 'utm',
+    install_requires=['setuptools', 'numpy', 'influxdb', 'requests>=2.21.0', 'python-dateutil', 'utm',
                       'matplotlib', 'Pillow', 'scipy', 'piexif', 'cryptography', 'pyyaml', 'pygdal>=2.2.2.*',]
 
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="agpypeline",
-    version="0.0.103",
+    version="0.0.47",
     author="Jacob van der Leeuw",
     author_email="jvanderleeuw@email.arizona.edu",
     description="Installable package for entrypoint and drone-specific environment code within a transformer",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="agpypeline",
-    version="0.0.106",
+    version="0.0.47",
     author="Jacob van der Leeuw",
     author_email="jvanderleeuw@email.arizona.edu",
     description="Installable package for entrypoint and drone-specific environment code within a transformer",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="agpypeline",
-    version="0.0.47",
+    version="0.0.104",
     author="Jacob van der Leeuw",
     author_email="jvanderleeuw@email.arizona.edu",
     description="Installable package for entrypoint and drone-specific environment code within a transformer",

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -150,7 +150,7 @@ def test_entrypoint_add_parameters():
         for arg in vars(args):
             assert arg in check_result and check_result[arg] == getattr(args, arg)
     except SystemExit:
-        assert False
+        assert False  # SystemExit exception was caught
 
 
 def test_entrypoint_do_work():


### PR DESCRIPTION
Related to https://github.com/AgPipeline/agpypeline/pull/23 . Changes were made based off of https://github.com/kyclark/transformer-canopycover/blob/kyc_testing/REVIEW.adoc in order to use argparse as a validator and to throw errors rather than do all error handling in the code itself. 

Additionally, changes were made to lasfile.py in order to use pdal rather than the outdated liblas library. Ubuntu was also changed from 18.04 to 20.04